### PR TITLE
all legendary dragons now caught

### DIFF
--- a/EverWingHax.py
+++ b/EverWingHax.py
@@ -166,7 +166,7 @@ def acquire_sidekicks():
         print("Round " + str(i+1) + " of " + str(num_rounds) + " ", end="")
         complete_games(10)
         acquire_eggs("epic", 80)
-        acquire_dragons("legendary", 8)
+        acquire_dragons("legendary", 10)
         print(" DONE")
         if i % 4 == 0:
             level_up_sidekicks()


### PR DESCRIPTION
Present code excludes two dragons from being caught. This fix is tested and gives the user all 9 currently available legendary dragons.